### PR TITLE
conflict when using picker popOver on a popOver contains the form

### DIFF
--- a/controllers/picker.js
+++ b/controllers/picker.js
@@ -29,6 +29,7 @@ var picker = {
   valueFormat: 'YYYY-MM-DD'
 };
 
+var forceIphoneBehavior = false;
 /**
  * Constructor.
  *
@@ -70,9 +71,11 @@ var picker = {
   $.setInput($.input);
 
   // compose view
-  if (Ti.Platform.osname === 'ipad') {
-    $.win.title = $.label.text;
-    $.win.add($.picker);
+  if (Ti.Platform.osname === 'ipad' && !args.forceIphoneBehavior) {
+      $.win.title = $.label.text;
+      $.win.add($.picker);
+  } else {
+      forceIphoneBehavior = args.forceIphoneBehavior;
   }
 
 })(arguments[0]);
@@ -101,7 +104,7 @@ function focus(e) {
 
   if (OS_IOS) {
 
-    if (Ti.Platform.osname === 'ipad') {
+    if (Ti.Platform.osname === 'ipad' && !forceIphoneBehavior) {
       $.popover.show({
         view: $.input
       });

--- a/controllers/picker.js
+++ b/controllers/picker.js
@@ -29,7 +29,7 @@ var picker = {
   valueFormat: 'YYYY-MM-DD'
 };
 
-var forceIphoneBehavior = false;
+var disablePopover = false;
 /**
  * Constructor.
  *
@@ -71,11 +71,11 @@ var forceIphoneBehavior = false;
   $.setInput($.input);
 
   // compose view
-  if (Ti.Platform.osname === 'ipad' && !args.forceIphoneBehavior) {
+  if (Ti.Platform.osname === 'ipad' && !args.disablePopover) {
       $.win.title = $.label.text;
       $.win.add($.picker);
   } else {
-      forceIphoneBehavior = args.forceIphoneBehavior;
+      forceIphoneBehavior = args.disablePopover;
   }
 
 })(arguments[0]);
@@ -104,7 +104,7 @@ function focus(e) {
 
   if (OS_IOS) {
 
-    if (Ti.Platform.osname === 'ipad' && !forceIphoneBehavior) {
+    if (Ti.Platform.osname === 'ipad' && !disablePopover) {
       $.popover.show({
         view: $.input
       });


### PR DESCRIPTION
when using the form on iPad contained in popOver, when click on picker the main popOver hide and picker popOver shows.

solved by a flag  "forceIphoneBehavior" passed to the field parameter so i can prevent the picker to show in a popOver